### PR TITLE
Criada as funções validateFormatoCpfCnpj e validateCpfCnpj

### DIFF
--- a/src/validator-docs/Validator.php
+++ b/src/validator-docs/Validator.php
@@ -34,6 +34,17 @@ class Validator extends BaseValidator
     }
 
     /**
+     * Valida o formato do cpf ou cnpj
+     * @param string $attribute
+     * @param string $value
+     * @return boolean
+     */
+    protected function validateFormatoCpfCnpj($attribute, $value)
+    {
+        return $this->validateFormatoCpf($attribute, $value) || $this->validateFormatoCnpj($attribute, $value);
+    }
+
+    /**
      * Valida se o CPF é válido
      * @param string $attribute
      * @param string $value
@@ -94,6 +105,17 @@ class Validator extends BaseValidator
 
         return true;
 
+    }
+
+    /**
+     * Valida se o CNPJ é válido
+     * @param string $attribute
+     * @param string $value
+     * @return boolean
+     */
+    protected function validateCpfCnpj($attribute, $value)
+    {
+        return ($this->validateCpf($attribute, $value) || $this->validateCnpj($attribute, $value));
     }
 
     /**

--- a/src/validator-docs/ValidatorProvider.php
+++ b/src/validator-docs/ValidatorProvider.php
@@ -40,8 +40,10 @@ class ValidatorProvider extends ServiceProvider
             'cnh' => 'O campo :attribute não é uma carteira nacional de habilitação válida',
             'cnpj' => 'O campo :attribute não é um CNPJ válido',
             'cpf' => 'O campo :attribute não é um CPF válido',
+            'cpf_cnpj' => 'O campo :attribute não é válido',
             'formato_cnpj' => 'O campo :attribute não possui o formato válido de CNPJ',
             'formato_cpf' => 'O campo :attribute não possui o formato válido de CPF',
+            'formato_cpf_cnpj' => 'O campo :attribute não possui um formato válido',
         ];
     }
 

--- a/tests/TestValidator.php
+++ b/tests/TestValidator.php
@@ -74,6 +74,43 @@ class TestValidator extends ValidatorTestCase
         $this->assertTrue($incorrect->fails());
     }
 
+
+    public function testCpfCnpj()
+    {
+        $correct = \Validator::make(
+            ['certo' => '53.084.587/0001-20'],
+            ['certo' => 'cpf-cnpj']
+        );
+
+        $incorrect = \Validator::make(
+            ['errado' => '99800-1926'],
+            ['errado' => 'cpf-cnpj']
+        );
+
+        $this->assertTrue($correct->passes());
+
+        $this->assertTrue($incorrect->fails());
+    }
+
+
+    public function testCpfCnpjFormato()
+    {
+        $correct = \Validator::make(
+            ['certo' => '094.050.986-59'],
+            ['certo' => 'formato-cpf-cnpj']
+        );
+
+        $incorrect = \Validator::make(
+            ['errado' => '51.084.587/000120'],
+            ['errado' => 'formato-cpf-cnpj']
+        );
+
+        $this->assertTrue($correct->passes());
+
+        $this->assertTrue($incorrect->fails());
+    }
+
+
     public function testCnh()
     {
         $correct = \Validator::make(


### PR DESCRIPTION
Criada as funções validateFormatoCpfCnpj e validateCpfCnpj, para quando no mesmo atributo for permitido cadastrar um cpf ou cnpj.