### PR TITLE
Inclusão do exemplo para validação de CPF/CNPJ no arquivo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/geekcom/validator-docs/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/geekcom/validator-docs/?branch=master)
 
-Biblioteca Laravel para validação de CPF, CNPJ e CNH.
+Biblioteca Laravel para validação de CPF, CNPJ, CPF/CNPJ (quando salvos no mesmo atributo) e CNH.
 
 # Instalação
 
@@ -28,13 +28,16 @@ Após a instalação, adicione no arquivo `config/app.php` no array `providers` 
 geekcom\ValidatorDocs\ValidatorProvider::class
 ```
 
-Para utilizar a validação agora, basta fazer o procedimento padrão do `Laravel`, confira na documentação especifica para a sua versão
+Para utilizar a validação agora, basta fazer o procedimento padrão do `Laravel`, confira na documentação especifica para a sua versão,
 a diferença é que agora, você terá os seguintes métodos de validação:
+
 
 * cnpj - Verifica se o CNPJ é valido. Para testar, basta utilizar o site http://www.geradorcnpj.com/
 * cpf - Verifica se o cpf é valido. Para testar, basta utilizar o site http://geradordecpf.org
+* cpf_cnpj - Verifica se é um cpf ou cnpj valido. Para testar, basta utilizar um dos sites acima
 * formato_cnpj - Verifica se a mascara do CNPJ é válida. ( 99.999.999/9999-99 )
 * formato_cpf - Verifica se a mascara do cpf é válida. ( 999.999.999-99 )
+* formato_cpf_cnpj - Verifica se a mascara do cpf ou cnpj é válida. ( 999.999.999-99 ) ou ( 99.999.999/9999-99 )
 
 
 Então, podemos usar um simples teste onde dizemos que o campo CPF será obrigatório e usamos a biblioteca para validar:
@@ -42,6 +45,14 @@ Então, podemos usar um simples teste onde dizemos que o campo CPF será obrigat
 ```php
 $this->validate($request, [
           'cpf' => 'required|cpf',
+      ]);
+```
+
+No exemplo abaixo, fazemos um teste onde validamos a formatação e a validade de um CPF ou CNPJ, para os casos onde a informação deva ser salva em um mesmo atributo:
+
+```php
+$this->validate($request, [
+          'cpf_or_cnpj' => 'formato_cpf_cnpj|cpf_cnpj',
       ]);
 ```
 


### PR DESCRIPTION
Inclusão no arquivo README.md de um exemplo das novas funções para validação de formato e validade de CPF/CPNJ, quando a informação é armazenada no mesmo atributo.