### PR TITLE
fixing "Unparenthesized is deprecated" error

### DIFF
--- a/src/validator-docs/Validator.php
+++ b/src/validator-docs/Validator.php
@@ -125,7 +125,7 @@ class Validator extends BaseValidator
 
         $dv2 = $s2 % 11 - ($dv1 > 9 ? 2 : 0);
 
-        $check = $dv2 < 0 ? $dv2 + 11 : $dv2 > 9 ? 0 : $dv2;
+        $check = $dv2 < 0 ? $dv2 + 11 : ($dv2 > 9 ? 0 : $dv2);
 
         return $value[10] == $check;
     }


### PR DESCRIPTION
So, PHP 7.4 throws an error and this PR fixes it.