### PR TITLE
Valida Inscrição Estadual para cada Unidade Federativa

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _Validação de documentos do Brasil usando **Laravel 6/7/8**_
 
 > Para a versão compatível com Laravel 5 consulte o branch https://github.com/geekcom/validator-docs/tree/5.x.x
 
-Biblioteca Laravel para validação de CPF, CNPJ, CPF/CNPJ (quando salvos no mesmo atributo), CNH, PIS/PASEP/NIT/NIS, Título de Eleitor, Cartão Nacional de Saúde(CNS) e Certidões(nascimento/casamento/óbito).
+Biblioteca Laravel para validação de CPF, CNPJ, CPF/CNPJ (quando salvos no mesmo atributo), CNH, PIS/PASEP/NIT/NIS, Inscrição Estadual, Título de Eleitor, Cartão Nacional de Saúde(CNS) e Certidões(nascimento/casamento/óbito).
 
 ## Instalação
 
@@ -80,6 +80,14 @@ $this->validate($request, [
 ```php
 $this->validate($request, [
     'cpf_cnpj' => 'required|cpf_cnpj',
+]);
+```
+
+* **inscricao_estadual** - Verifica se uma Inscrição Estadual é valida para uma unidade federarativa (UF).
+
+```php
+$this->validate($request, [
+    'inscricao_estadual' => 'required|inscricao_estadual:BA',
 ]);
 ```
 
@@ -193,6 +201,7 @@ public function store(Request $request)
 * **NIS** - https://www.4devs.com.br/gerador_de_pis_pasep
 * **CNS** - https://geradornv.com.br/gerador-cns/
 * **CERTIDÃO** - https://www.treinaweb.com.br/ferramentas-para-desenvolvedores/gerador/certidao
+* **INSCRIÇÃO ESTADUAL** - https://www.4devs.com.br/gerador_de_inscricao_estadual
 
 Fique a vontade para contribuir fazendo um fork.
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     }
   ],
   "require": {
-    "php": "^7.2"
+    "php": "^7.2",
+    "thiagocfn/inscricaoestadual": "^1.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.4",

--- a/src/validator-docs/Rules/InscricaoEstadual.php
+++ b/src/validator-docs/Rules/InscricaoEstadual.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace geekcom\ValidatorDocs\Rules;
+
+use Thiagocfn\InscricaoEstadual\Util\Validador;
+
+final class InscricaoEstadual extends Sanitization
+{
+    public function validateInscricaoEstadual($attribute, $value, $parameters)
+    {
+        if(empty($parameters[0]) || !is_string($parameters[0])) {
+            return false;
+        }
+        $siglaUf = $this->sanitizeSiglaUf($parameters[0]);
+        $inscricaoEstadual = $this->sanitize($value);
+        return Validador::check($siglaUf, $inscricaoEstadual);
+    }
+
+    /**
+     * @param mixed $siglaUf
+     * @return false|string|string[]
+     */
+    private function sanitizeSiglaUf($siglaUf)
+    {
+        return mb_strtoupper($siglaUf);
+    }
+}

--- a/src/validator-docs/Validator.php
+++ b/src/validator-docs/Validator.php
@@ -12,6 +12,7 @@ use geekcom\ValidatorDocs\Rules\Cpf;
 use geekcom\ValidatorDocs\Rules\Cnpj;
 use geekcom\ValidatorDocs\Rules\Cnh;
 use geekcom\ValidatorDocs\Rules\Certidao;
+use geekcom\ValidatorDocs\Rules\InscricaoEstadual;
 
 use function preg_match;
 
@@ -102,5 +103,12 @@ class Validator extends BaseValidator
         $certidao = new Certidao();
 
         return $certidao->validateCertidao($attribute, $value);
+    }
+
+    protected function validateInscricaoEstadual($attribute, $value, $parameters): bool
+    {
+        $inscricaoEstadual = new InscricaoEstadual();
+
+        return $inscricaoEstadual->validateInscricaoEstadual($attribute, $value, $parameters);
     }
 }

--- a/src/validator-docs/ValidatorProvider.php
+++ b/src/validator-docs/ValidatorProvider.php
@@ -39,6 +39,7 @@ class ValidatorProvider extends ServiceProvider
             'cpf_cnpj' => 'CPF ou CNPJ inválido',
             'nis' => 'PIS/PASEP/NIT/NIS inválido',
             'cns' => 'Cartão Nacional de Saúde inválido',
+            'inscricao_estadual' => 'Inscrição Estadual ou UF inválidas',
             'certidao' => 'Número da Certidão inválido',
             'formato_cnpj' => 'Formato inválido para CNPJ',
             'formato_cpf' => 'Formato inválido para CPF',

--- a/tests/TestValidator.php
+++ b/tests/TestValidator.php
@@ -265,4 +265,122 @@ final class TestValidator extends ValidatorTestCase
         );
         $this->assertTrue($correct->passes());
     }
+
+    public function inscricoesEstaduais()
+    {
+        $inscricoesEstaduaisValidas = [
+            "AC" => "0184765932153",
+            "AL" => "248308335",
+            "AP" => "039895661",
+            "AM" => "292278012",
+            "BA" => "96338555",
+            "CE" => "980874165",
+            "DF" => "0740769300107",
+            "ES" => "342048090",
+            "GO" => "107900459",
+            "MA" => "122917510",
+            "MT" => "55160385510",
+            "MS" => "283814659",
+            "MG" => "0526366324132",
+            "PA" => "158330005",
+            "PB" => "439622301",
+            "PR" => "5714953410",
+            "PE" => "920145698",
+            "PI" => "758505183",
+            "RJ" => "61804315",
+            "RN" => "208627715",
+            "RS" => "3821957672",
+            "RO" => "52059985926850",
+            "RR" => "249977060",
+            "SC" => "696192667",
+            "SP" => "653172024009",
+            "SE" => "646597361",
+            "TO" => "75036274184",
+        ];
+
+        foreach ($inscricoesEstaduaisValidas as $siglaUf => $inscricaoEstadual) {
+            $inscricoesEstaduaisValidas[$siglaUf] = [
+                'data' => $inscricaoEstadual,
+                'rules' => "inscricao_estadual:$siglaUf",
+                'assert' => 'passes'
+            ];
+        }
+
+        return $inscricoesEstaduaisValidas + [
+            // válidas
+            'válida sem formatação' => [
+                'data' => '82679341',
+                'rules' => 'inscricao_estadual:BA',
+                'assert' => 'passes'
+            ],
+            'válida com estado (UF) em letras minúsculas' => [
+                'data' => '82679341',
+                'rules' => 'inscricao_estadual:ba',
+                'assert' => 'passes'
+            ],
+            'válida com formatação' => [
+                'data' => '826793-41',
+                'rules' => 'inscricao_estadual:BA',
+                'assert' => 'passes'
+            ],
+            'válida com formatação qualquer não-numérica' => [
+                'data' => '8 2__6-7*9.3/41',
+                'rules' => 'inscricao_estadual:BA',
+                'assert' => 'passes'
+            ],
+
+            // inválidas
+            'inválida cálculo errado' => [
+                'data' => '82679342', // último digito deveria ser 1
+                'rules' => 'inscricao_estadual:BA',
+                'assert' => 'fails'
+            ],
+            'inválida se estado (UF) errado' => [
+                'data' => '82679341',
+                'rules' => 'inscricao_estadual:SP', // deveria ser BA
+                'assert' => 'fails'
+            ],
+            'inválida se estado (UF) inexistente' => [
+                'data' => '82679341',
+                'rules' => 'inscricao_estadual:ZA',
+                'assert' => 'fails'
+            ],
+            'inválida se estado (UF) invalido (maior)' => [
+                'data' => '82679341',
+                'rules' => 'inscricao_estadual:askdjahsd',
+                'assert' => 'fails'
+            ],
+            'inválida se estado (UF) invalido (menor)' => [
+                'data' => '82679341',
+                'rules' => 'inscricao_estadual:y',
+                'assert' => 'fails'
+            ],
+            'inválida se estado (UF) invalido (numerico)' => [
+                'data' => '82679341',
+                'rules' => 'inscricao_estadual:12',
+                'assert' => 'fails'
+            ],
+            'inválida se estado (UF) não informado' => [
+                'data' => '82679341',
+                'rules' => 'inscricao_estadual',
+                'assert' => 'fails'
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider inscricoesEstaduais
+     * @param $data
+     * @param $rules
+     * @param $assert
+     */
+    public function inscricaoEstadual($data, $rules, $assert)
+    {
+        $correct = Validator::make(
+            ['input_inscricao_estadual' => $data],
+            ['input_inscricao_estadual' => $rules]
+        );
+        $this->assertTrue($correct->{$assert}());
+    }
 }


### PR DESCRIPTION
Resolve #94.
- Cria uma nova Laravel Validation Rule para Inscrição Estadual;
- Valida de acordo com a Unidade Federativa informada;
- Usei uma lib de um xará meu https://github.com/Thiagocfn/InscricaoEstadual
    - Apesar de poucas atualizações recentes, me parece suficientemente boa.
- Adicionei dezenas de casos de teste para que o validator-docs verifique o comportamento independentemente da solução adotada.