### PR TITLE
Adicionado teste no PHP 8 e Atualizado dependências

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 7.2
   - 7.3
   - 7.4
+  - 8.0
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,13 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": ">=7.2",
     "thiagocfn/inscricaoestadual": "^1.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.4",
+    "phpunit/phpunit": "^8.4|^9.4",
     "orchestra/testbench": "^4.0",
-    "symplify/changelog-linker": "^6.1",
+    "symplify/changelog-linker": "^8.3",
     "php-coveralls/php-coveralls": "^2.2",
     "squizlabs/php_codesniffer": "*",
     "phpstan/phpstan": "^0.12.5"


### PR DESCRIPTION
# Objetivo
Esse PR tem o intuito de adicionar o suporte oficial ao PHP 8.

# Mudanças propostas
- Adicionado PHP 8 na configuração do trevis ci
- Atualização dos pacotes para compatibilidade do PHP 8

### Observação
O projeto atualmente usa travis.org, esse site será descontinuado 31 de dezembro de 2020, sugiro a migração para o travis.com.
Fonte: https://mailchi.mp/3d439eeb1098/travis-ciorg-is-moving-to-travis-cicom