### PR TITLE
Fix Sanitization class to deal with null values

### DIFF
--- a/src/validator-docs/Rules/Sanitization.php
+++ b/src/validator-docs/Rules/Sanitization.php
@@ -10,6 +10,6 @@ abstract class Sanitization
 {
     public function sanitize($value): string
     {
-        return preg_replace('/[^\d]/', '', $value);
+        return empty($value) ? "" : preg_replace('/[^\d]/', '', $value);
     }
 }

--- a/tests/SanitizationTestCase.php
+++ b/tests/SanitizationTestCase.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace geekcom\ValidatorDocs\Tests;
+
+use geekcom\ValidatorDocs\Rules\Sanitization;
+use Illuminate\Support\Facades\Validator;
+
+final class SanitizationTestCase extends ValidatorTestCase
+{
+    /** @test **/
+    public function sanitizeRetornaVazioQuandoNuloOuVazio()
+    {
+        $mock = $this->getMockForAbstractClass(Sanitization::class);
+        $this->assertEquals($mock->sanitize(null), "");
+    }
+
+    /** @test **/
+    public function sanitizeRetornaSomenteDigitos()
+    {
+        $mock = $this->getMockForAbstractClass(Sanitization::class);
+        $this->assertEquals($mock->sanitize('a53.084.587/0001-20z'), "53084587000120");
+    }
+}


### PR DESCRIPTION
O título do PR é auto explicativo. Testando no Laravel 8 e recebendo o campo em branco, o `preg_replace` falha porque não é string|array e sim null.